### PR TITLE
Reagents bank toggle in Bagnon bank menu

### DIFF
--- a/localization/cn.lua
+++ b/localization/cn.lua
@@ -23,6 +23,7 @@ L.FrameSettingsDesc = '窗口显示设置'
 --L.Enabled = 'Enable Frame'
 --L.CharacterSpecific = 'Character Specific Settings'
 --L.ExclusiveReagent = 'Separate Reagent Bank'
+--L.ReagentbankToggle = 'Reagent Bank Toggle'
 
 L.BagFrame = '启用背包按钮'
 L.Money = '启用货币窗口'

--- a/localization/de.lua
+++ b/localization/de.lua
@@ -30,6 +30,7 @@ L.Broker = 'Databroker'
 L.Sort = 'Sortierschaltfläche'
 L.Search = 'Suchsschaltfläche'
 L.Options = 'Optionenschaltfläche'
+L.ReagentbankToggle = 'Materiallager'
 
 L.Appearance = 'Erscheinung'
 L.Layer = 'Ebene'

--- a/localization/en.lua
+++ b/localization/en.lua
@@ -37,6 +37,7 @@ L.Broker = 'Databroker Plugins'
 L.Sort = 'Sort Button'
 L.Search = 'Search Toggle'
 L.Options = 'Options Button'
+L.ReagentbankToggle = 'Reagent Bank Toggle'
 L.ExclusiveReagent = 'Separate Reagent Bank'
 L.LeftTabs = 'Rulesets on Left'
 L.LeftTabsTip = [[

--- a/localization/es.lua
+++ b/localization/es.lua
@@ -30,6 +30,7 @@ L.Broker = 'DataBroker'
 L.Sort = 'Botón para ordenar'
 L.Search = 'Botón para buscar'
 L.Options = 'Botón de opciones'
+L.ReagentbankToggle = 'Banco de componentes'
 
 L.Appearance = 'Aparencia'
 L.Layer = 'Estrato'

--- a/localization/fr.lua
+++ b/localization/fr.lua
@@ -40,6 +40,7 @@ L.Sort = 'Bouton de tri'
 L.Search = 'Champ de recherche'
 L.Options = 'Affichage des options'
 L.ExclusiveReagent = 'Séparer la banque des composants'
+L.ReagentbankToggle = 'Banque des composants'
 
 L.Appearance = 'Apparence'
 L.Layer = 'Couche'

--- a/localization/it.lua
+++ b/localization/it.lua
@@ -23,6 +23,7 @@ L.Frame = 'Finestra'
 L.Enabled = 'Attiva la finestra'
 --L.CharacterSpecific = 'Character Specific Settings'
 --L.ExclusiveReagent = 'Separate Reagent Bank'
+--L.ReagentbankToggle = 'Reagent Bank Toggle'
 
 L.BagFrame = 'Attiva riquadro borse'
 L.Money = 'Riquadro delle monete'

--- a/localization/ko.lua
+++ b/localization/ko.lua
@@ -22,6 +22,7 @@ L.Frame = '창'
 L.Enabled = '애드온 사용'
 L.CharacterSpecific = '캐릭터 개별 설정'
 L.ExclusiveReagent = '재료 은행 별도 표시'
+L.ReagentbankToggle = '재료 은행'
 
 L.BagFrame = '가방 표시'
 L.Money = '소지금 표시'

--- a/localization/pt.lua
+++ b/localization/pt.lua
@@ -23,6 +23,7 @@ L.Frame = 'Janela'
 L.Enabled = 'Ativar'
 L.CharacterSpecific = 'Preferências Específicas por Personagem'
 --L.ExclusiveReagent = 'Separate Reagent Bank'
+--L.ReagentbankToggle = 'Reagent Bank Toggle'
 
 L.BagFrame = 'Lista de sacos'
 L.Money = 'Dinheiro'

--- a/localization/ru.lua
+++ b/localization/ru.lua
@@ -23,6 +23,7 @@ L.Frame = 'Окно'
 L.Enabled = 'Включить окна'
 L.CharacterSpecific = 'Настройки для текущего персонажа'
 L.ExclusiveReagent = 'Отдельный банк материалов'
+L.ReagentbankToggle = 'банк материалов'
 
 L.BagFrame = 'Кнопка сумок'
 L.Money = 'Золото'

--- a/localization/tw.lua
+++ b/localization/tw.lua
@@ -23,6 +23,7 @@ L.Frame = '框架'
 L.Enabled = '啟用框架'
 --L.CharacterSpecific = 'Character Specific Settings'
 L.ExclusiveReagent = '分離材料銀行'
+--L.ReagentbankToggle = 'Reagent Bank Toggle'
 
 L.BagFrame = '背包列表'
 L.Money = '金錢'

--- a/panels.lua
+++ b/panels.lua
@@ -80,6 +80,10 @@ Addon.FrameOptions = Addon.Options:NewPanel(ADDON, L.FrameSettings, L.FrameSetti
 				if self.frameID ~= 'vault' then
 					row:CreateCheck('money')
 				end
+
+				if self.frameID == 'bank' then
+					row:CreateCheck('reagentbankToggle')
+				end
 			end
 
 			if Config.tabs then


### PR DESCRIPTION
I have now implemented a reagents bank toggle for the Bagnon bank menu, as described in my feature request from last week (https://github.com/tullamods/Bagnon/issues/795). This required modifications in Bagnon, Wildpants, Bagnon_Config and Wildpants_Config. (See my other pull requests.)

I hope my coding was conform with what you were intending with your code. Otherwise please let me know!